### PR TITLE
handle updates to getPrefixStream prop

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -271,18 +271,26 @@ export class PullFlatList<T> extends Component<PullFlatListProps<T>, State<T>> {
 
   public componentDidUpdate(prevProps: PullFlatListProps<T>) {
     const nextProps = this.props;
-    const nextGetReadable = nextProps.getScrollStream;
-    const prevGetReadable = prevProps.getScrollStream;
+    const { getScrollStream: nextGetScrollReadable, getPrefixStream: nextGetPrefixReadable } = nextProps;
+    const { getScrollStream: prevGetScrollReadable, getPrefixStream: prevGetPrefixReadable } = prevProps;
 
-    if (nextGetReadable !== prevGetReadable) {
+    if (nextGetScrollReadable !== prevGetScrollReadable) {
       this.stopScrollListener(() => {
         if (!this.unmounting) {
           this.isPulling = false;
           this.morePullQueue = 0;
           this.iteration = 0;
-          this.startScrollListener(nextGetReadable?.());
+          this.startScrollListener(nextGetScrollReadable?.());
         }
       });
+    }
+
+    if (nextGetPrefixReadable !== prevGetPrefixReadable) {
+      this.stopPrefixListener(() => {
+        if (!this.unmounting) {
+          this.startPrefixListener(nextGetPrefixReadable?.());
+        }
+      })
     }
   }
 
@@ -340,9 +348,13 @@ export class PullFlatList<T> extends Component<PullFlatListProps<T>, State<T>> {
     }
   }
 
-  public stopPrefixListener() {
+  public stopPrefixListener(cb?: () => void) {
     if (this.prefixReadable) {
       this.prefixReadable(true, () => {});
+    }
+
+    if (this.unmounting) {
+      cb?.();
     }
   }
 


### PR DESCRIPTION
while debugging a [PR for Manyverse](https://gitlab.com/staltz/manyverse/-/merge_requests/297), @staltz and I discovered some issues around how the prefix works in this component, one of which is that it doesn't resubscribe to the prefix stream when the prop updates (it only does it on mount at the moment)

there are a couple of areas in these changes that I'm unsure about due to lack of context with the state and various fields, so need feedback on that